### PR TITLE
fix SliceRemoteFile vcf and index input

### DIFF
--- a/wdl/Vep.wdl
+++ b/wdl/Vep.wdl
@@ -66,8 +66,8 @@ workflow Vep {
       if (any_remote) {
         call SliceRemoteFiles {
           input:
-            vcf = vcf,
-            vcf_idx = vcf_idx,
+            vcf = shard_info.left,
+            vcf_idx = shard_info.right,
             gnomad_vcf_uris = gnomad_vcf_uris,
             gnomad_vcf_indexes = gnomad_vcf_indexes,
             gnomad_infos = gnomad_infos,


### PR DESCRIPTION
I believe this task is receiving the wrong vcfs for extracting the query region from, causing it pull everything for all shards?